### PR TITLE
php(-nts)-xdebug: Update to version 3.4.7-8.4, fix checkver & autoupdate

### DIFF
--- a/bucket/p/php-nts-xdebug.json
+++ b/bucket/p/php-nts-xdebug.json
@@ -1,0 +1,65 @@
+{
+    "version": "3.4.7-8.4",
+    "description": "An extension for PHP to assist with debugging and development. (Non Thread Safe)",
+    "homepage": "https://xdebug.org/",
+    "license": {
+        "identifier": "Xdebug-1.01",
+        "url": "https://xdebug.org/license"
+    },
+    "notes": [
+        "Xdebug is already enabled if PHP (Non Thread Safe) was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://xdebug.org/files/php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll#/php_xdebug.dll",
+            "hash": "1585d961e311bf138ff4cd98d04c3092c4fa00f8133b26f70a6bf946d23c43aa"
+        }
+    },
+    "post_install": [
+        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=debug`nxdebug.start_with_request=yes`nxdebug.discover_client_host=true\"",
+        "if (installed php-nts $true) {",
+        "    $ini_path = \"$(persistdir php-nts $true)\\cli\\conf.d\\xdebug.ini\"",
+        "} elseif (installed php-nts $false) {",
+        "    $ini_path = \"$(persistdir php-nts)\\cli\\conf.d\\xdebug.ini\"",
+        "} else {",
+        "    Write-Host -f Yellow \"`nPHP (Non Thread Safe) was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
+        "    Write-Host -f Cyan \"$ini`n\"",
+        "    Write-Host -f Yellow \"to your php.ini file\"",
+        "}",
+        "if ($ini_path) {",
+        "    if (Test-Path $ini_path) {",
+        "        Write-Output \"`nNo XDebug config was added, as xdebug.ini already exists in $ini_path\"",
+        "    } else {",
+        "        Write-Output \"`nEnabling extension $ini_path\"",
+        "        Add-Content -Value $ini -Path $ini_path",
+        "    }",
+        "}"
+    ],
+    "checkver": {
+        "url": "https://xdebug.org/download/historical",
+        "script": [
+            "$xdebug_regex = 'php_xdebug(?=[^'']+nts)-(?<prefix>[\\d.]+)-(?<suffix>[\\d.]+)(?<=\\d)[^'']+dll'",
+            "$latest_xdebug = [regex]::Matches($page, $xdebug_regex) | ForEach-Object {",
+            "    [pscustomobject]@{",
+            "        FileName = $_.Value",
+            "        XdebugVersion = [version]$_.Groups['prefix'].Value",
+            "        PHPVersion = [version]$_.Groups['suffix'].Value",
+            "    }",
+            "} | Sort-Object XdebugVersion, PHPVersion -Descending | Select-Object -First 1",
+            "Write-Output \"$($latest_xdebug.XdebugVersion)-$($latest_xdebug.PHPVersion) / $($latest_xdebug.FileName)\""
+        ],
+        "regex": "([\\d.-]+) / (?<name>.+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://xdebug.org/files/$matchName#/php_xdebug.dll",
+                "hash": {
+                    "url": "https://xdebug.org/download/historical",
+                    "regex": "\"SHA256:&nbsp;$sha256\" href='/files/$basename'"
+                }
+            }
+        }
+    }
+}

--- a/bucket/p/php-xdebug.json
+++ b/bucket/p/php-xdebug.json
@@ -1,0 +1,65 @@
+{
+    "version": "3.4.7-8.4",
+    "description": "An extension for PHP to assist with debugging and development. (Thread Safe)",
+    "homepage": "https://xdebug.org/",
+    "license": {
+        "identifier": "Xdebug-1.01",
+        "url": "https://xdebug.org/license"
+    },
+    "notes": [
+        "Xdebug is already enabled if PHP was installed through scoop!",
+        "Otherwise add '$dir\\php_xdebug.dll' to your php.ini"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://xdebug.org/files/php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll#/php_xdebug.dll",
+            "hash": "15e5c20a7ac0576f9cc0cd437b2adc2dad71d49904388760ff9145c22b46cb1a"
+        }
+    },
+    "post_install": [
+        "$ini = \"zend_extension=$dir\\php_xdebug.dll`n[xdebug]`nxdebug.mode=debug`nxdebug.start_with_request=yes`nxdebug.discover_client_host=true\"",
+        "if (installed php $true) {",
+        "    $ini_path = \"$(persistdir php $true)\\cli\\conf.d\\xdebug.ini\"",
+        "} elseif (installed php $false) {",
+        "    $ini_path = \"$(persistdir php)\\cli\\conf.d\\xdebug.ini\"",
+        "} else {",
+        "    Write-Host -f Yellow \"`nPHP was not installed through scoop, you have to activate php_xdebug.dll manually! Add the following:`n\"",
+        "    Write-Host -f Cyan \"$ini`n\"",
+        "    Write-Host -f Yellow \"to your php.ini file\"",
+        "}",
+        "if ($ini_path) {",
+        "    if (Test-Path $ini_path) {",
+        "        Write-Output \"`nNo XDebug config was added, as xdebug.ini already exists in $ini_path\"",
+        "    } else {",
+        "        Write-Output \"`nEnabling extension $ini_path\"",
+        "        Add-Content -Value $ini -Path $ini_path",
+        "    }",
+        "}"
+    ],
+    "checkver": {
+        "url": "https://xdebug.org/download/historical",
+        "script": [
+            "$xdebug_regex = 'php_xdebug(?![^'']+nts)-(?<prefix>[\\d.]+)-(?<suffix>[\\d.]+)(?<=\\d)[^'']+dll'",
+            "$latest_xdebug = [regex]::Matches($page, $xdebug_regex) | ForEach-Object {",
+            "    [pscustomobject]@{",
+            "        FileName = $_.Value",
+            "        XdebugVersion = [version]$_.Groups['prefix'].Value",
+            "        PHPVersion = [version]$_.Groups['suffix'].Value",
+            "    }",
+            "} | Sort-Object XdebugVersion, PHPVersion -Descending | Select-Object -First 1",
+            "Write-Output \"$($latest_xdebug.XdebugVersion)-$($latest_xdebug.PHPVersion) / $($latest_xdebug.FileName)\""
+        ],
+        "regex": "([\\d.-]+) / (?<name>.+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://xdebug.org/files/$matchName#/php_xdebug.dll",
+                "hash": {
+                    "url": "https://xdebug.org/download/historical",
+                    "regex": "\"SHA256:&nbsp;$sha256\" href='/files/$basename'"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Updates both `php-xdebug` and `php-nts-xdebug` to version **3.4.7-8.4**, corrects upstream asset naming changes, and rebuilds the `checkver` / `autoupdate` logic to ensure reliable version detection and hashing.

### Changes

- Updated version to **3.4.7-8.4** for both manifests
- Updated download URLs and SHA256 hashes to match the latest upstream assets
- Rewrote `checkver` using a PowerShell script to:
  - Parse asset names from *historical* downloads instead of the main page  
  - Extract Xdebug version and PHP API version via regex groups  
  - Sort and select the newest compatible file dynamically
- Updated `autoupdate` to:
  - Use `$matchName` for fully dynamic asset resolution
  - Add a new hash-matching regex compatible with the historical download page
- Unified logic between the TS and NTS manifests for maintainability

### Testing

```powershell
┏[ D:\Software\Scoop\Local\apps\scoop\current\bin][ master ≡]
└─> .\checkver.ps1 -App php-* -Dir "D:\Temporary\Software\Microsoft\Windows Sandbox\Repositories\Scoop\Buckets\Extras\bucket" -f                
php-nts-xdebug: 3.4.7-8.4 (scoop version is 3.4.7-8.4)
Forcing autoupdate!
Autoupdating php-nts-xdebug
DEBUG[1763819790] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1763819790] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1763819790] $substitutions.$patchVersion                  7
DEBUG[1763819790] $substitutions.$minorVersion                  4
DEBUG[1763819790] $substitutions.$matchHead                     3.4.7
DEBUG[1763819790] $substitutions.$underscoreVersion             3_4_7_8_4
DEBUG[1763819790] $substitutions.$baseurl                       https://xdebug.org/files
DEBUG[1763819790] $substitutions.$urlNoExt                      https://xdebug.org/files/php_xdebug-3.4.7-8.4-nts-vs17-x86_64
DEBUG[1763819790] $substitutions.$version                       3.4.7-8.4
DEBUG[1763819790] $substitutions.$majorVersion                  3
DEBUG[1763819790] $substitutions.$dashVersion                   3-4-7-8-4
DEBUG[1763819790] $substitutions.$match1                        3.4.7-8.4
DEBUG[1763819790] $substitutions.$matchTail                     -8.4
DEBUG[1763819790] $substitutions.$preReleaseVersion             8.4
DEBUG[1763819790] $substitutions.$basenameNoExt                 php_xdebug-3.4.7-8.4-nts-vs17-x86_64
DEBUG[1763819790] $substitutions.$url                           https://xdebug.org/files/php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll
DEBUG[1763819790] $substitutions.$buildVersion
DEBUG[1763819790] $substitutions.$matchName                     php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll
DEBUG[1763819790] $substitutions.$cleanVersion                  34784
DEBUG[1763819790] $substitutions.$dotVersion                    3.4.7.8.4
DEBUG[1763819790] $substitutions.$basename                      php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll
DEBUG[1763819790] $hashfile_url = https://xdebug.org/download/historical -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for php_xdebug-3.4.7-8.4-nts-vs17-x86_64.dll in https://xdebug.org/download/historical
DEBUG[1763819791] $regex = "SHA256:&nbsp;([a-fA-F0-9]{64})" href='/files/php_xdebug-3\.4\.7-8\.4-nts-vs17-x86_64\.dll' -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: 1585d961e311bf138ff4cd98d04c3092c4fa00f8133b26f70a6bf946d23c43aa using Extract Mode
Writing updated php-nts-xdebug manifest
php-xdebug: 3.4.7-8.4 (scoop version is 3.4.7-8.4)
Forcing autoupdate!
Autoupdating php-xdebug
DEBUG[1763819792] [$updatedProperties] = [url hash] -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:491:5
DEBUG[1763819792] $substitutions (hashtable) -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:221:5
DEBUG[1763819792] $substitutions.$patchVersion                  7
DEBUG[1763819792] $substitutions.$minorVersion                  4
DEBUG[1763819792] $substitutions.$matchHead                     3.4.7
DEBUG[1763819792] $substitutions.$underscoreVersion             3_4_7_8_4
DEBUG[1763819792] $substitutions.$baseurl                       https://xdebug.org/files
DEBUG[1763819792] $substitutions.$urlNoExt                      https://xdebug.org/files/php_xdebug-3.4.7-8.4-ts-vs17-x86_64
DEBUG[1763819792] $substitutions.$version                       3.4.7-8.4
DEBUG[1763819792] $substitutions.$majorVersion                  3
DEBUG[1763819792] $substitutions.$dashVersion                   3-4-7-8-4
DEBUG[1763819792] $substitutions.$match1                        3.4.7-8.4
DEBUG[1763819792] $substitutions.$matchTail                     -8.4
DEBUG[1763819792] $substitutions.$preReleaseVersion             8.4
DEBUG[1763819792] $substitutions.$basenameNoExt                 php_xdebug-3.4.7-8.4-ts-vs17-x86_64
DEBUG[1763819792] $substitutions.$url                           https://xdebug.org/files/php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll
DEBUG[1763819792] $substitutions.$buildVersion
DEBUG[1763819792] $substitutions.$matchName                     php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll
DEBUG[1763819792] $substitutions.$cleanVersion                  34784
DEBUG[1763819792] $substitutions.$dotVersion                    3.4.7.8.4
DEBUG[1763819792] $substitutions.$basename                      php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll
DEBUG[1763819792] $hashfile_url = https://xdebug.org/download/historical -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:224:5
Searching hash for php_xdebug-3.4.7-8.4-ts-vs17-x86_64.dll in https://xdebug.org/download/historical
DEBUG[1763819793] $regex = "SHA256:&nbsp;([a-fA-F0-9]{64})" href='/files/php_xdebug-3\.4\.7-8\.4-ts-vs17-x86_64\.dll' -> D:\Software\Scoop\Local\apps\scoop\current\lib\autoupdate.ps1:78:9
Found: 15e5c20a7ac0576f9cc0cd437b2adc2dad71d49904388760ff9145c22b46cb1a using Extract Mode
Writing updated php-xdebug manifest
```

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md)