### PR TITLE
kazumi: Add version 2.1.6

### DIFF
--- a/bucket/p/Predidit/kazumi.json
+++ b/bucket/p/Predidit/kazumi.json
@@ -1,0 +1,34 @@
+{
+    "version": "2.1.6",
+    "description": "A rule-based anime streaming application with support for custom content extraction, real-time Anime4K upscaling, screen casting, hardware acceleration, and more.",
+    "homepage": "https://kazumi.app",
+    "license": {
+        "identifier": "GPL-3.0-or-later",
+        "url": "https://github.com/Predidit/Kazumi/blob/HEAD/LICENSE"
+    },
+    "suggest": {
+        "Microsoft Visual C++ 2015-2022 Redistributable": "extras/vcredist2022"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Predidit/Kazumi/releases/download/2.1.6/Kazumi_windows_2.1.6.zip",
+            "hash": "eebda751fdce674ebc848be9f630944358723f17993862eea9733d0ee4489c9e"
+        }
+    },
+    "shortcuts": [
+        [
+            "kazumi.exe",
+            "Kazumi"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/Predidit/Kazumi"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Predidit/Kazumi/releases/download/$version/Kazumi_windows_$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add a manifest for [kazumi](https://kazumi.app) version 2.1.6.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
