### PR TITLE
hibit-startup-manager: Add version 2.6.60

### DIFF
--- a/bucket/h/HiBitSoftware/hibit-startup-manager.json
+++ b/bucket/h/HiBitSoftware/hibit-startup-manager.json
@@ -1,0 +1,22 @@
+{
+    "version": "2.6.60",
+    "description": "A tool for viewing and managing all applications configured to start automatically with Windows.",
+    "homepage": "https://www.hibitsoft.ir/StartupManager.html",
+    "license": "Freeware",
+    "url": "https://www.hibitsoft.ir/HibitStartup/HiBitStartupManager-Portable-2.6.60.zip",
+    "hash": "f226ee99275a1be0b3bebd3b36e3a226e4b74ee91c1278bca21f47f3992ea3b1",
+    "shortcuts": [
+        [
+            "HiBitStartupManager-Portable.exe",
+            "HiBit Startup Manager"
+        ]
+    ],
+    "persist": "HiBitStartupManager",
+    "checkver": {
+        "url": "https://www.hibitsoft.ir/HibitStartup/Changelog.txt",
+        "regex": "Startup Manager\\s*([\\d.]+)"
+    },
+    "autoupdate": {
+        "url": "https://www.hibitsoft.ir/HibitStartup/HiBitStartupManager-Portable-$version.zip"
+    }
+}


### PR DESCRIPTION
Add a manifest for [hibit-startup-manager](https://www.hibitsoft.ir/StartupManager.html) version 2.6.60.

- [x] Use conventional PR title: `<manifest-name[@version]|chore>: <general summary of the pull request>`
- [x] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md) <!-- where the first check box is documented, in case you don't read. -->
